### PR TITLE
fix(security): patch CVE-2022-41404 DoS vulnerability (CRITICAL)

### DIFF
--- a/src/main/java/org/ini4j/BasicProfileSection.java
+++ b/src/main/java/org/ini4j/BasicProfileSection.java
@@ -34,6 +34,11 @@ class BasicProfileSection extends BasicOptionMap implements Profile.Section {
   }
 
   @Override
+  Config getConfig() {
+    return _profile.getConfig();
+  }
+
+  @Override
   public Profile.Section getChild(String key) {
     return _profile.get(childName(key));
   }
@@ -114,6 +119,20 @@ class BasicProfileSection extends BasicOptionMap implements Profile.Section {
   @Override
   void resolve(StringBuilder buffer) {
     _profile.resolve(buffer, this);
+  }
+
+  @Override
+  protected String fetchInternal(Object key, int index, int depth) {
+    String value = get(key, index);
+
+    if (hasVariableSubstitution(value)) {
+      StringBuilder buffer = new StringBuilder(value);
+
+      _profile.resolve(buffer, this, depth);
+      value = buffer.toString();
+    }
+
+    return value;
   }
 
   private String childName(String key) {

--- a/src/main/java/org/ini4j/CircularReferenceException.java
+++ b/src/main/java/org/ini4j/CircularReferenceException.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2005,2009 Ivan SZKIBA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ini4j;
+
+/**
+ * Exception thrown when a circular reference is detected during variable resolution.
+ *
+ * <p>This exception is thrown when the maximum recursion depth is exceeded while resolving variable
+ * substitutions in INI files or option maps. This typically indicates a circular reference in the
+ * configuration, such as:
+ *
+ * <pre>
+ * [section1]
+ * a = ${section2/b}
+ *
+ * [section2]
+ * b = ${section1/a}
+ * </pre>
+ *
+ * <p>This exception prevents {@link StackOverflowError} that would otherwise occur from infinite
+ * recursion.
+ *
+ * <p><b>Security Note:</b> This exception is part of the fix for CVE-2022-41404, which addressed a
+ * Denial of Service vulnerability where circular variable references could crash the JVM.
+ *
+ * @see Config#getMaxResolveDepth()
+ * @see Config#setMaxResolveDepth(int)
+ * @since 0.6.0
+ */
+public class CircularReferenceException extends IllegalArgumentException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a new circular reference exception with the specified maximum resolve depth.
+   *
+   * @param maxResolveDepth the maximum recursion depth that was exceeded
+   */
+  public CircularReferenceException(int maxResolveDepth) {
+    super(
+        "Variable resolution depth limit ("
+            + maxResolveDepth
+            + ") exceeded. "
+            + "Circular reference detected in variable substitution. "
+            + "Check for circular dependencies in variable references. "
+            + "Increase org.ini4j.config.maxResolveDepth if legitimate deep nesting is needed.");
+  }
+
+  /**
+   * Constructs a new circular reference exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public CircularReferenceException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new circular reference exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause
+   */
+  public CircularReferenceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/ini4j/Config.java
+++ b/src/main/java/org/ini4j/Config.java
@@ -42,6 +42,7 @@ public class Config implements Cloneable, Serializable {
   public static final String PROP_LINE_SEPARATOR = "lineSeparator";
   public static final String PROP_COMMENT = "comment";
   public static final String PROP_HEADER_COMMENT = "headerComment";
+  public static final String PROP_MAX_RESOLVE_DEPTH = "maxResolveDepth";
   public static final boolean DEFAULT_EMPTY_OPTION = false;
   public static final boolean DEFAULT_EMPTY_SECTION = false;
   public static final boolean DEFAULT_GLOBAL_SECTION = false;
@@ -63,6 +64,7 @@ public class Config implements Cloneable, Serializable {
   public static final char DEFAULT_PATH_SEPARATOR = '/';
   public static final String DEFAULT_LINE_SEPARATOR = getSystemProperty("line.separator", "\n");
   public static final Charset DEFAULT_FILE_ENCODING = Charset.forName("UTF-8");
+  public static final int DEFAULT_MAX_RESOLVE_DEPTH = 16;
   private static final Config GLOBAL = new Config();
   private static final long serialVersionUID = 2865793267410367814L;
   private boolean _comment;
@@ -86,6 +88,7 @@ public class Config implements Cloneable, Serializable {
   private boolean _strictOperator;
   private boolean _tree;
   private boolean _unnamedSection;
+  private int _maxResolveDepth;
 
   public Config() {
     reset();
@@ -295,6 +298,14 @@ public class Config implements Cloneable, Serializable {
     return _escapeKeyOnly;
   }
 
+  public int getMaxResolveDepth() {
+    return _maxResolveDepth;
+  }
+
+  public void setMaxResolveDepth(int value) {
+    _maxResolveDepth = value;
+  }
+
   @Override
   public Config clone() {
     try {
@@ -326,6 +337,7 @@ public class Config implements Cloneable, Serializable {
     _fileEncoding = getCharset(PROP_FILE_ENCODING, DEFAULT_FILE_ENCODING);
     _comment = getBoolean(PROP_COMMENT, DEFAULT_COMMENT);
     _headerComment = getBoolean(PROP_HEADER_COMMENT, DEFAULT_HEADER_COMMENT);
+    _maxResolveDepth = getInt(PROP_MAX_RESOLVE_DEPTH, DEFAULT_MAX_RESOLVE_DEPTH);
   }
 
   private boolean getBoolean(String name, boolean defaultValue) {
@@ -348,5 +360,19 @@ public class Config implements Cloneable, Serializable {
 
   private String getString(String name, String defaultValue) {
     return getSystemProperty(KEY_PREFIX + name, defaultValue);
+  }
+
+  private int getInt(String name, int defaultValue) {
+    String value = getSystemProperty(KEY_PREFIX + name);
+
+    if (value == null) {
+      return defaultValue;
+    }
+
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
   }
 }


### PR DESCRIPTION
Implement configurable recursion depth limit to prevent stack overflow from circular variable references in INI file variable substitution.

## Changes

- Add CircularReferenceException for clear error reporting
- Add Config.maxResolveDepth property (default: 16, configurable via -Dorg.ini4j.config.maxResolveDepth=N)
- Implement depth tracking through fetchInternal() methods in BasicProfile and BasicOptionMap
- Add package-protected getConfig() methods for config access
- Add hasVariableSubstitution() helper to check for ${...} patterns

## Security Impact

**CVE-2022-41404: Denial of Service via infinite recursion**
- Attack vector: Circular references like [a] x=${b/y} and [b] y=${a/x}
- Impact: StackOverflowError crashes JVM
- Mitigation: Throw CircularReferenceException when depth limit exceeded

## Testing

- Add 3 regression tests for circular reference detection:
  * BasicProfileTest.testFetchRecursiveInfiniteLoop
  * BasicOptionMapTest.testFetchCircularReference  
  * BasicProfileSectionTest.testFetchCircularReferenceAcrossSections
- All 206 tests passing

## Acknowledgments

Thanks to [bingdian](https://sourceforge.net/u/bingdians/profile/) for the original vulnerability report on SourceForge ticket #56.

Additional thanks to Marc Lafon, paradox, and Craig for their contributions to identifying and documenting this issue.

Fixes #6